### PR TITLE
Update Actions to Handle Develop and Reconfigure gh-pages

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -5,10 +5,12 @@ on:
     branches:
       - main
       - master
+      - develop
   pull_request:
     branches:
       - main
       - master
+      - develop
   release:
     types:
       - created

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -19,7 +19,7 @@ jobs:
   "unittest_reveng_paj7620":
      strategy:
        matrix:
-         os: [ubuntu-latest, macos-latest, windows-latest]
+         os: [ubuntu-latest]
      runs-on: ${{ matrix.os }}
      steps:
        - uses: actions/checkout@v2

--- a/.github/workflows/doxygen.yaml
+++ b/.github/workflows/doxygen.yaml
@@ -24,7 +24,7 @@ jobs:
            doxyfile-path: "./Doxyfile"
            working-directory: "."
        - name: Switch to stable version
-         if: startsWith(github.ref, 'main') || startsWith(github.ref, 'master')
+         if: endsWith(github.ref, 'main') || endsWith(github.ref, 'master')
          run: echo "DEPLOY_DIR=stable" >> $GITHUB_ENV
        - name: Determine If Doc Version Is Tag
          id: prepare_tag

--- a/.github/workflows/doxygen.yaml
+++ b/.github/workflows/doxygen.yaml
@@ -25,7 +25,7 @@ jobs:
            working-directory: "."
        - name: Switch to stable version
          if: startsWith(github.ref, 'main') || startsWith(github.ref, 'master')
-         run: echo "DEPLOY_DIR=${GITHUB_REF##refs/branches}" >> $GITHUB_ENV
+         run: echo "DEPLOY_DIR=\"\"" >> $GITHUB_ENV
        - name: Determine If Doc Version Is Tag
          id: prepare_tag
          if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/doxygen.yaml
+++ b/.github/workflows/doxygen.yaml
@@ -5,9 +5,13 @@ on:
     branches:
       - main
       - master
+      - develop
   release:
     types:
       - created
+
+env:
+  DEPLOY_DIR: "latest"
 
 jobs:
   "generate_reveng_paj7620_docs":
@@ -19,11 +23,27 @@ jobs:
          with:
            doxyfile-path: "./Doxyfile"
            working-directory: "."
+       - name: Switch to stable version
+         if: startsWith(github.ref, 'main') || startsWith(github.ref, 'master')
+         run: echo "DEPLOY_DIR=${GITHUB_REF##refs/branches}" >> $GITHUB_ENV
+       - name: Determine If Doc Version Is Tag
+         id: prepare_tag
+         if: startsWith(github.ref, 'refs/tags/')
+         run: |
+           TAG_NAME="${GITHUB_REF##refs/tags/}"
+           echo "DEPLOY_DIR=${TAG_NAME}" >> $GITHUB_ENV
+           echo "::set-output name=tag_name::${TAG_NAME}"
+           echo "::set-output name=deploy_tag_name::docs-deploy-${TAG_NAME}"
+         
        - uses: peaceiris/actions-gh-pages@v3
          name: Publish to GitHub pages
          with:
            github_token: ${{ secrets.GITHUB_TOKEN }}
            publish_dir: ./doxygen/html
+           destination_dir: "${{ env.DEPLOY_DIR }}"
+           commit_message: "Publish Docs ${{ env.DEPLOY_DIR }}"
+           tag_name: ${{ steps.prepare_tag.outputs.deploy_tag_name }}
+           tag_message: "Docs Deployment ${{ steps.prepare_tag.outputs.tag_name }}"
        - uses: actions/upload-artifact@v2
          name: Upload all Doxygen artifacts
          with:

--- a/.github/workflows/doxygen.yaml
+++ b/.github/workflows/doxygen.yaml
@@ -25,7 +25,7 @@ jobs:
            working-directory: "."
        - name: Switch to stable version
          if: startsWith(github.ref, 'main') || startsWith(github.ref, 'master')
-         run: echo "DEPLOY_DIR=\"\"" >> $GITHUB_ENV
+         run: echo "DEPLOY_DIR=stable" >> $GITHUB_ENV
        - name: Determine If Doc Version Is Tag
          id: prepare_tag
          if: startsWith(github.ref, 'refs/tags/')

--- a/Doxyfile
+++ b/Doxyfile
@@ -170,7 +170,7 @@ FULL_PATH_NAMES        = YES
 # will be relative from the directory where doxygen is started.
 # This tag requires that the tag FULL_PATH_NAMES is set to YES.
 
-STRIP_FROM_PATH        = src/
+STRIP_FROM_PATH        = src/ examples/
 
 # The STRIP_FROM_INC_PATH tag can be used to strip a user-defined part of the
 # path mentioned in the documentation of a class, which tells the reader which


### PR DESCRIPTION
This PR modifies the test action to run on the `develop` branch. It also modifies the doxygen action to generate the doxygen docs on the `gh-pages` branch with the following:

- Each release's docs are placed into their own subdirectory named based upon the tag used to create the release.
- Each run on `develop` updates the documentation in the `latest` subdirectory
- Each run on `master`/`main` updates the documentation in the `stable` subdirectory
- Navigation to the main `index.html` page automatically redirects to the `stable` documentation.
