### PR TITLE
Added const to writeRegisterArray method signature to fix compilation errors

### DIFF
--- a/src/RevEng_PAJ7620.cpp
+++ b/src/RevEng_PAJ7620.cpp
@@ -201,7 +201,7 @@ bool RevEng_PAJ7620::isPAJ7620UDevice()
 
 /****************************************************************
 ****************************************************************/
-void RevEng_PAJ7620::writeRegisterArray(unsigned short array[], int arraySize)
+void RevEng_PAJ7620::writeRegisterArray(const unsigned short array[], int arraySize)
 {
   for (unsigned int i = 0; i < arraySize; i++)
   {

--- a/src/RevEng_PAJ7620.h
+++ b/src/RevEng_PAJ7620.h
@@ -465,7 +465,7 @@ class RevEng_PAJ7620
     bool isPAJ7620UDevice();
     void initializeDeviceSettings();
 
-    void writeRegisterArray(unsigned short array[], int arraySize);
+    void writeRegisterArray(const unsigned short array[], int arraySize);
 };
 
 #endif


### PR DESCRIPTION
Fixes compilation errors due to passing the pointer for `setCursorRegisterArray`, which is `const`, to `writeRegisterArray`  which accepts non-const pointers.

Solution: Modify `writeRegisterArray` to only accept `const` pointers.