### PR TITLE
Fix release rev to default to merge into develop rather than master.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,7 @@ on:
         required: true
       baseBranch:
         description: "Branch to base release off of"
-        default: "master"
+        default: "develop"
         required: true
 
 jobs:
@@ -38,7 +38,7 @@ jobs:
          with:
            commit-message: "[Automated] Rev Version to ${{github.event.inputs.newVersion}}"
            branch: $NEW_BRANCH_NAME
-           base: "master"
+           base: ${{ github.event.inputs.baseBranch }}
            title: "[Automated] Rev Version to ${{github.event.inputs.newVersion}}"
            body: |
              Automated Update


### PR DESCRIPTION
Currently the release rev workflow creates a PR into `master`. This is probably incorrect.

This PR updates that workflow to merge into whatever base branch is provided by the user when starting the workflow (defaulting to `develop`)